### PR TITLE
AB#1010 setting html element properties

### DIFF
--- a/G1ANT.Addon.Selenium.sln
+++ b/G1ANT.Addon.Selenium.sln
@@ -18,9 +18,7 @@ Global
 		{3A10D8A2-7812-41ED-AB27-2C60F3B856D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3A10D8A2-7812-41ED-AB27-2C60F3B856D5}.Release|Any CPU.Build.0 = Release|Any CPU
 		{067E5148-0829-44D5-92CE-8AAC1CEB7E45}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{067E5148-0829-44D5-92CE-8AAC1CEB7E45}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{067E5148-0829-44D5-92CE-8AAC1CEB7E45}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{067E5148-0829-44D5-92CE-8AAC1CEB7E45}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/G1ANT.Addon.Selenium/Api/Enums/AttributeOperationType.cs
+++ b/G1ANT.Addon.Selenium/Api/Enums/AttributeOperationType.cs
@@ -1,0 +1,33 @@
+﻿
+
+using System;
+/**
+*    Copyright(C) G1ANT Ltd, All rights reserved
+*    Solution G1ANT.Addon, Project G1ANT.Addon.Selenium
+*    www.g1ant.com
+*
+*    Licensed under the G1ANT license.
+*    See License.txt file in the project root for full license information.
+*
+*/
+namespace G1ANT.Addon.Selenium.Api.Enums
+{
+    public enum AttributeOperationType
+    {
+        PreferAttribute,
+        ForceAttribute,
+        ForceProperty,
+        Default = PreferAttribute
+    }
+
+    public static class AttributeOperationTypeParser
+    {
+        public static AttributeOperationType Parse(string operationTypeName)
+        {
+            if (string.IsNullOrEmpty(operationTypeName))
+                return AttributeOperationType.Default;
+
+            return (AttributeOperationType)Enum.Parse(typeof(AttributeOperationType), operationTypeName, true);
+        }
+    }
+}

--- a/G1ANT.Addon.Selenium/Api/SeleniumExtensions.cs
+++ b/G1ANT.Addon.Selenium/Api/SeleniumExtensions.cs
@@ -9,10 +9,7 @@
 */
 using OpenQA.Selenium;
 using OpenQA.Selenium.Internal;
-using OpenQA.Selenium.Support.UI;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace G1ANT.Addon.Selenium
 {
@@ -23,11 +20,45 @@ namespace G1ANT.Addon.Selenium
             return (IJavaScriptExecutor)driver;
         }
 
+
+        /// <summary>Sets attribute of an element (the one from element.attributes)</summary>
+        /// <param name="element"></param>
+        /// <param name="name"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
         public static IWebElement SetAttribute(this IWebElement element, string name, string value)
         {
             var driver = ((IWrapsDriver)element).WrappedDriver;
             var jsExecutor = (IJavaScriptExecutor)driver;
             jsExecutor.ExecuteScript("arguments[0].setAttribute(arguments[1], arguments[2]);", element, name, value);
+            return element;
+        }
+
+        public static bool IsAttribute(this IWebElement element, string name)
+        {
+            var driver = ((IWrapsDriver)element).WrappedDriver;
+            var jsExecutor = (IJavaScriptExecutor)driver;
+            var isAttribute = name != "innerHTML" // getAttribute returns "innerHTML" for this name while it should return null
+                && (bool)jsExecutor.ExecuteScript("return arguments[0].getAttribute(arguments[1]) != null", element, name);
+
+            return isAttribute;
+            
+        }
+
+        /// <summary>Sets property of an element (element.name = value), handles cases like `value` or `selectedIndex`</summary>
+        /// <param name="element"></param>
+        /// <param name="name"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static IWebElement SetProperty(this IWebElement element, string name, string value)
+        {
+            var driver = ((IWrapsDriver)element).WrappedDriver;
+            var jsExecutor = (IJavaScriptExecutor)driver;
+
+            if (!int.TryParse(value, out _))
+                value = $"'{value.Replace("'", "\\'")}'";
+
+            jsExecutor.ExecuteScript($"arguments[0].{name} = {value};", element);
             return element;
         }
 

--- a/G1ANT.Addon.Selenium/Api/SeleniumWrapper.cs
+++ b/G1ANT.Addon.Selenium/Api/SeleniumWrapper.cs
@@ -7,6 +7,7 @@
 *    See License.txt file in the project root for full license information.
 *
 */
+using G1ANT.Addon.Selenium.Api.Enums;
 using G1ANT.Language;
 using OpenQA.Selenium;
 using OpenQA.Selenium.IE;
@@ -344,14 +345,36 @@ namespace G1ANT.Addon.Selenium
             popupHandler.Finish();
         }
 
+        public void SetAttributeValue(string attributeName, string attributeValue, AttributeOperationType setAttributeType, SeleniumCommandArguments search, TimeSpan timeout)
+        {
+            var element = GetElementInFrame(search, timeout);
+            if (element != null)
+            {
+                if (IsAttributeOprtationType(element, attributeName, setAttributeType))
+                    element.SetAttribute(attributeName, attributeValue);
+                else
+                    element.SetProperty(attributeName, attributeValue);
+            }
+            if (string.IsNullOrEmpty(search.IFrameSearch?.Value) == false)
+                webDriver.SwitchTo().DefaultContent();
+        }
+
+        private bool IsAttributeOprtationType(IWebElement element, string attributeName, AttributeOperationType setAttributeType)
+        {
+            return setAttributeType == AttributeOperationType.ForceAttribute
+                || (setAttributeType == AttributeOperationType.PreferAttribute && element.IsAttribute(attributeName));
+        }
+
         public string GetAttributeValue(string attributeName, SeleniumCommandArguments search)
         {
             var element = GetElementInFrame(search, search.Timeout.Value);
 
-            string res = element?.GetAttribute(attributeName) ?? string.Empty;
+            var result = element?.GetAttribute(attributeName);
+
             if (string.IsNullOrEmpty(search.IFrameSearch?.Value) == false)
                 webDriver.SwitchTo().DefaultContent();
-            return res;
+
+            return result ?? string.Empty;
         }
 
         public string GetAttributeValue(string attributeName, string elementXPath, SeleniumIFrameArguments search)
@@ -445,14 +468,6 @@ namespace G1ANT.Addon.Selenium
             dataTable.Rows.Add(cellValues);
 
             return dataTable;
-        }
-
-        public void SetAttributeValue(string attributeName, string attributeValue, SeleniumCommandArguments search, TimeSpan timeout)
-        {
-            var element = GetElementInFrame(search, timeout);
-            element?.SetAttribute(attributeName, attributeValue);
-            if (string.IsNullOrEmpty(search.IFrameSearch?.Value) == false)
-                webDriver.SwitchTo().DefaultContent();
         }
 
         private IWebElement GetElementInFrame(SeleniumCommandArguments search, TimeSpan timeout)

--- a/G1ANT.Addon.Selenium/Commands/SeleniumSetAttributeCommand.cs
+++ b/G1ANT.Addon.Selenium/Commands/SeleniumSetAttributeCommand.cs
@@ -7,8 +7,10 @@
 *    See License.txt file in the project root for full license information.
 *
 */
+using G1ANT.Addon.Selenium.Api.Enums;
 using G1ANT.Language;
 using System;
+using static G1ANT.Addon.Selenium.SeleniumWrapper;
 
 namespace G1ANT.Addon.Selenium
 {
@@ -18,25 +20,31 @@ namespace G1ANT.Addon.Selenium
     {
         public class Arguments : SeleniumCommandArguments
         {
-            [Argument(Required = true, Tooltip = "Name of an attribute to set its value")]
+            [Argument(Required = true, Tooltip = "Name of an attribute or property to set its value")]
             public TextStructure Name { get; set; }
 
             [Argument(Tooltip = "Value to set")]
-            public TextStructure Value { get; set; }
+            public TextStructure Value { get; set; } = new TextStructure("");
+
+            [Argument(Tooltip = "Force setting attribute or property. 'ForceAttribute' to set html element attribute (like data-id), 'ForceProperty' to set DOM element property (like value, name or selectedIndex), 'PreferAttribute' or 'Default' to set atribute with fallback to property. Default is 'PreferAttribute'")]
+            public TextStructure Type { get; set; } = new TextStructure(AttributeOperationType.Default.ToString());
 
             [Argument(DefaultVariable = "timeoutselenium", Tooltip = "Specifies time in milliseconds for G1ANT.Robot to wait for the command to be executed")]
-            public  override TimeSpanStructure Timeout { get; set; } = new TimeSpanStructure(SeleniumSettings.SeleniumTimeout);
+            public override TimeSpanStructure Timeout { get; set; } = new TimeSpanStructure(SeleniumSettings.SeleniumTimeout);
         }
+
         public SeleniumSetAttributeCommand(AbstractScripter scripter) : base(scripter)
-        {
-        }
+        { }
+
+
         public void Execute(Arguments arguments)
         {
             try
             {
                 SeleniumManager.CurrentWrapper.SetAttributeValue(
                     arguments.Name.Value,
-                    arguments.Value?.Value ?? string.Empty,
+                    arguments.Value.Value,
+                    AttributeOperationTypeParser.Parse(arguments.Type.Value),
                     arguments,
                     arguments.Timeout.Value);
             }

--- a/G1ANT.Addon.Selenium/G1ANT.Addon.Selenium.csproj
+++ b/G1ANT.Addon.Selenium/G1ANT.Addon.Selenium.csproj
@@ -77,6 +77,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Api\CustomExpectedConditions.cs" />
+    <Compile Include="Api\Enums\AttributeOperationType.cs" />
     <Compile Include="Api\Enums\BrowserType.cs" />
     <Compile Include="Api\Enums\ElementSearchBy.cs" />
     <Compile Include="Api\SeleniumIFrameArguments.cs" />
@@ -165,7 +166,6 @@
     <Error Condition="!Exists('..\packages\Selenium.WebDriver.ChromeDriver.80.0.3987.10600\build\Selenium.WebDriver.ChromeDriver.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Selenium.WebDriver.ChromeDriver.80.0.3987.10600\build\Selenium.WebDriver.ChromeDriver.targets'))" />
     <Error Condition="!Exists('..\packages\Selenium.WebDriver.IEDriver.3.150.1\build\Selenium.WebDriver.IEDriver.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Selenium.WebDriver.IEDriver.3.150.1\build\Selenium.WebDriver.IEDriver.targets'))" />
   </Target>
-
   <Import Project="..\packages\Selenium.Firefox.WebDriver.0.26.0\build\Selenium.Firefox.WebDriver.targets" Condition="Exists('..\packages\Selenium.Firefox.WebDriver.0.26.0\build\Selenium.Firefox.WebDriver.targets')" />
   <Import Project="..\packages\Selenium.WebDriver.ChromeDriver.80.0.3987.10600\build\Selenium.WebDriver.ChromeDriver.targets" Condition="Exists('..\packages\Selenium.WebDriver.ChromeDriver.80.0.3987.10600\build\Selenium.WebDriver.ChromeDriver.targets')" />
   <Import Project="..\packages\Selenium.WebDriver.IEDriver.3.150.1\build\Selenium.WebDriver.IEDriver.targets" Condition="Exists('..\packages\Selenium.WebDriver.IEDriver.3.150.1\build\Selenium.WebDriver.IEDriver.targets')" />


### PR DESCRIPTION
while Selenium's GetAttribute works both with attributes and properties, there is no native SetAttribute, setting attribute is performed by js. Js distinguishes between attribute and property, therefore previous version of setAttribute didn't work with properties (like value, selectedIndex). This commit fixes this behavior while maintaining some backward compatibility.